### PR TITLE
perf: minor adjustments

### DIFF
--- a/exchange-algo/src/standard/orderbook/mod.rs
+++ b/exchange-algo/src/standard/orderbook/mod.rs
@@ -1,6 +1,7 @@
 mod index;
 
 use std::collections::btree_map::Entry;
+use std::collections::VecDeque;
 use std::marker::PhantomData;
 
 use exchange_core::Asset;
@@ -69,7 +70,7 @@ impl Exchange for Orderbook {
                     .limit_price()
                     .expect("bookable orders must have a limit price"),
             )
-            .or_default()
+            .or_insert_with(|| VecDeque::with_capacity(8))
             .push_back(order.id());
 
         self.orders_by_id.insert(order.id(), order);

--- a/exchange/src/main.rs
+++ b/exchange/src/main.rs
@@ -2,7 +2,6 @@ use std::fs;
 use std::io;
 use std::io::BufRead;
 use std::path::PathBuf;
-use std::sync::mpsc;
 use std::time::Instant;
 
 use anyhow::Result;
@@ -34,7 +33,7 @@ struct Args {
 fn main() -> Result<()> {
     let args = Args::parse();
 
-    let (tx, rx) = mpsc::sync_channel(128 * 1024);
+    let (tx, rx) = crossbeam::channel::bounded(128 * 1024);
 
     std::thread::spawn(move || -> Result<()> {
         let mut reader = io::BufReader::new(args.input.unwrap_or_default());


### PR DESCRIPTION
Minor adjustments to finally reach the 1M/s mark 🎉

```sh
$ time cargo r --release --bin generator -- -n 5000000 -j 2 | time cargo r --release
       Total 5 000 000 order(s) in 5.00s
     Average 1 000 051.81 orders/s

 Orderbook info
    Spread
     Ask 7 363
     Bid 4 889
    Length
     Ask 548 050
     Bid 541 117

        5.50 real         9.47 user         0.32 sys
cargo r --release --bin generator -- -n 5000000 -j 2  4.49s user 0.80s system 99% cpu 5.325 total
time cargo r --release  9.47s user 0.33s system 177% cpu 5.507 total