### PR TITLE
perf: fix stdin/stdout `clap` arg parsing

### DIFF
--- a/matching-engine/matching-engine/src/main.rs
+++ b/matching-engine/matching-engine/src/main.rs
@@ -15,7 +15,7 @@ use owo_colors::OwoColorize;
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
-#[derive(Parser)]
+#[derive(Debug, Parser)]
 #[clap(author, version, about)]
 struct Args {
     #[clap(short, long, default_value = "BTC/USDC")]
@@ -124,7 +124,10 @@ impl fmt::Display for Input {
 impl From<&str> for Input {
     #[inline]
     fn from(s: &str) -> Self {
-        Input::File(s.to_owned().into())
+        match s {
+            "stdin" | "/dev/stdin" => Input::Stdin,
+            s => Input::File(s.to_owned().into()),
+        }
     }
 }
 
@@ -157,6 +160,9 @@ impl fmt::Display for Output {
 impl From<&str> for Output {
     #[inline]
     fn from(s: &str) -> Self {
-        Output::File(s.to_owned().into())
+        match s {
+            "stdout" | "/dev/stdout" => Output::Stdout,
+            s => Output::File(s.to_owned().into()),
+        }
     }
 }


### PR DESCRIPTION
Fix performance degradation after commit 301dff07b7976555478613b249a4fc1a505ca65b.

Also improves the 1M/s mark achieved in #84 by 10% 🎉

```shell
$ time cargo r --release --bin generator -- -n 5000000 -j 4 | time cargo r --release
     Running `target/release/matching-engine`
     Running `target/release/generator -n 5000000 -j 4`
       Total 5 000 000 order(s) in 4.34s
     Average 1 151 469.55 orders/s

 Orderbook info
    Spread
     Ask 5961
     Bid 3273
    Length
     Ask 544 668
     Bid 541 244
```