### PR TITLE
perf: use multiple workers to read stdin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ assert2 = "0.3.14"
 clap = "4.5"
 compact_str = "0.7"
 criterion = "0.5"
-crossbeam = "0.8"
 either = "1.12"
 insta = "1.39"
 mimalloc = { version = "0.1", default-features = false }

--- a/matching-engine/matching-engine/Cargo.toml
+++ b/matching-engine/matching-engine/Cargo.toml
@@ -15,10 +15,11 @@ anyhow = { workspace = true }
 arrayvec = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
 compact_str = { workspace = true, features = ["serde"] }
-crossbeam = { workspace = true, features = ["crossbeam-channel"] }
+crossbeam-channel = "0.5.13"
 mimalloc = { workspace = true }
 num_cpus = { workspace = true }
 owo-colors = { workspace = true }
+parking_lot = "0.12.3"
 rand = { workspace = true }
 rust_decimal = { workspace = true }
 serde = { workspace = true, features = ["derive"] }


### PR DESCRIPTION
Minor adjustments to nearly hit the 1.5 M/s milestone 🎉

30% faster than #86

```shell
$ cargo r --release --bin generator -- -n 5000000 -j 4 | cargo r --bin matching-engine --profile bench -- -j 4
    Finished `release` profile [optimized] target(s) in 0.08s
     Running `target/release/generator -n 5000000 -j 4`
    Finished `bench` profile [optimized + debuginfo] target(s) in 0.09s
     Running `target/release/matching-engine -j 4`
       Total 5 000 000 order(s) in 3.36s
     Average 1 487 083.35 orders/s

 Orderbook info
    Spread
     Ask 4531
     Bid 2805
    Length
     Ask 543698
     Bid 546012
```