### PR TITLE
perf: use `slab` as KV storage

### DIFF
--- a/exchange-core/src/exchange.rs
+++ b/exchange-core/src/exchange.rs
@@ -47,7 +47,9 @@ pub trait Exchange {
     /// Removes an order from the exchange.
     fn remove(
         &mut self,
-        order: &<Self::Order as Asset>::OrderId,
+        side: &<Self::Order as Asset>::OrderSide,
+        level: &<Self::Order as Asset>::OrderPrice,
+        order_id: &<Self::Order as Asset>::OrderId,
     ) -> Option<Self::Order>;
 
     /// Returns a reference of the most relevant order in the exchange.

--- a/exchange-types/src/order_request.rs
+++ b/exchange-types/src/order_request.rs
@@ -30,6 +30,8 @@ pub enum OrderRequest {
         side: OrderSide,
     },
     Delete {
+        side: OrderSide,
+        limit_price: Price,
         order_id: Uuid,
     },
 }

--- a/matching-engine/matching-engine-algo/Cargo.toml
+++ b/matching-engine/matching-engine-algo/Cargo.toml
@@ -12,6 +12,7 @@ exchange-types = { path = "../../exchange-types" }
 
 either = { workspace = true }
 num = { workspace = true }
+slab = "0.4.9"
 thiserror = { workspace = true }
 
 [dev-dependencies]

--- a/matching-engine/matching-engine-algo/src/lib.rs
+++ b/matching-engine/matching-engine-algo/src/lib.rs
@@ -53,7 +53,11 @@ impl<O> Algo<O> for MatchingAlgo {
             };
 
             if top_order.is_closed() {
-                let top_order_id = top_order.id();
+                let (top_order_side, top_order_limit_price, top_order_id) = (
+                    top_order.side(),
+                    top_order.limit_price().unwrap(),
+                    top_order.id(),
+                );
 
                 // We must explicity drop to reuse the `exchange`.
                 drop(top_order);
@@ -61,7 +65,11 @@ impl<O> Algo<O> for MatchingAlgo {
                 // As long as top order is completed, it can be safely removed
                 // from orderbook.
                 exchange
-                    .remove(&top_order_id)
+                    .remove(
+                        &top_order_side,
+                        &top_order_limit_price,
+                        &top_order_id,
+                    )
                     .expect("order should be `Some`");
             }
         }

--- a/matching-engine/matching-engine-algo/src/orderbook/index/orders_by_id.rs
+++ b/matching-engine/matching-engine-algo/src/orderbook/index/orders_by_id.rs
@@ -1,20 +1,26 @@
-use std::collections::BTreeMap;
 use std::ops::Deref;
 use std::ops::DerefMut;
 
 use exchange_core::Asset;
+use slab::Slab;
 
-pub struct OrdersById<Order: Asset>(BTreeMap<<Order as Asset>::OrderId, Order>);
+pub struct OrdersById<Order: Asset>(Slab<Order>);
+
+impl<Order: Asset> OrdersById<Order> {
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self(Slab::with_capacity(capacity))
+    }
+}
 
 impl<Order: Asset> Default for OrdersById<Order> {
     #[inline]
     fn default() -> Self {
-        Self(Default::default())
+        Self(Slab::default())
     }
 }
 
 impl<Order: Asset> Deref for OrdersById<Order> {
-    type Target = BTreeMap<<Order as Asset>::OrderId, Order>;
+    type Target = Slab<Order>;
 
     #[inline]
     fn deref(&self) -> &Self::Target {

--- a/matching-engine/matching-engine-algo/src/orderbook/index/orders_by_price.rs
+++ b/matching-engine/matching-engine-algo/src/orderbook/index/orders_by_price.rs
@@ -6,7 +6,10 @@ use std::ops::DerefMut;
 use exchange_core::Asset;
 
 pub struct OrdersByPrice<Order: Asset>(
-    BTreeMap<<Order as Asset>::OrderPrice, VecDeque<<Order as Asset>::OrderId>>,
+    BTreeMap<
+        <Order as Asset>::OrderPrice,
+        VecDeque<(usize, <Order as Asset>::OrderId)>,
+    >,
 );
 
 impl<Order: Asset> Default for OrdersByPrice<Order> {
@@ -19,7 +22,7 @@ impl<Order: Asset> Default for OrdersByPrice<Order> {
 impl<Order: Asset> Deref for OrdersByPrice<Order> {
     type Target = BTreeMap<
         <Order as Asset>::OrderPrice,
-        VecDeque<<Order as Asset>::OrderId>,
+        VecDeque<(usize, <Order as Asset>::OrderId)>,
     >;
 
     #[inline]

--- a/matching-engine/matching-engine-algo/src/orderbook/index/orders_by_side.rs
+++ b/matching-engine/matching-engine-algo/src/orderbook/index/orders_by_side.rs
@@ -23,7 +23,7 @@ where
     pub fn iter(
         &self,
         side: &<Order as Asset>::OrderSide,
-    ) -> impl Iterator<Item = &<Order as Asset>::OrderId> {
+    ) -> impl Iterator<Item = &(usize, <Order as Asset>::OrderId)> {
         match side {
             OrderSide::Ask => Either::Left(
                 self[side].deref().values().flat_map(VecDeque::iter),
@@ -38,7 +38,7 @@ where
     pub fn peek(
         &self,
         side: &<Order as Asset>::OrderSide,
-    ) -> Option<&<Order as Asset>::OrderId> {
+    ) -> Option<&(usize, <Order as Asset>::OrderId)> {
         self.iter(side).next()
     }
 }

--- a/matching-engine/matching-engine-rt/src/lib.rs
+++ b/matching-engine/matching-engine-rt/src/lib.rs
@@ -36,8 +36,16 @@ impl Engine {
                 let order = Order::try_from(incoming_order).unwrap();
                 let _ = self.orderbook.matching(order);
             }
-            OrderRequest::Delete { order_id } => {
-                self.orderbook.remove(&OrderId::new(order_id));
+            OrderRequest::Delete {
+                side,
+                limit_price,
+                order_id,
+            } => {
+                self.orderbook.remove(
+                    &side,
+                    &limit_price,
+                    &OrderId::new(order_id),
+                );
             }
         };
 

--- a/matching-engine/matching-engine/benches/in_memory.rs
+++ b/matching-engine/matching-engine/benches/in_memory.rs
@@ -16,9 +16,10 @@ pub fn in_memory(c: &mut Criterion) {
     let mut rng = rand::thread_rng();
 
     let mut orders = (1..).map(|_| match rng.gen_range(0..1_000) {
-        0 => OrderRequest::Delete {
-            order_id: Uuid::new_v4(),
-        },
+        // TODO: reimplement delete generator.
+        // 0 => OrderRequest::Delete {
+        //     order_id: Uuid::new_v4(),
+        // },
         _ => OrderRequest::Create {
             account_id: Uuid::new_v4(),
             amount: rng.gen_range(100..10_000).into(),

--- a/matching-engine/matching-engine/src/bin/generator.rs
+++ b/matching-engine/matching-engine/src/bin/generator.rs
@@ -76,20 +76,15 @@ fn worker(tx: &Sender<Message>, rng: &mut rand::rngs::ThreadRng) {
         })
     });
 
-    let order = match rng.gen_range(0..1_000) {
-        0 => OrderRequest::Delete {
-            order_id: Uuid::from_bytes(rng.gen::<[u8; 16]>()),
-        },
-        _ => OrderRequest::Create {
-            account_id: Uuid::from_bytes(rng.gen::<[u8; 16]>()),
-            amount: Decimal::from(rng.gen_range(100..10_000)).into(),
-            order_id: Uuid::from_bytes(rng.gen::<[u8; 16]>()),
-            symbol: CompactString::new_inline("BTC/USDC"),
-            limit_price: Decimal::from(rng.gen_range(100..10_000)).into(),
-            side: match side_distribution.sample(rng) {
-                true => OrderSide::Ask,
-                false => OrderSide::Bid,
-            },
+    let order = OrderRequest::Create {
+        account_id: Uuid::from_bytes(rng.gen::<[u8; 16]>()),
+        amount: Decimal::from(rng.gen_range(100..10_000)).into(),
+        order_id: Uuid::from_bytes(rng.gen::<[u8; 16]>()),
+        symbol: CompactString::new_inline("BTC/USDC"),
+        limit_price: Decimal::from(rng.gen_range(100..10_000)).into(),
+        side: match side_distribution.sample(rng) {
+            true => OrderSide::Ask,
+            false => OrderSide::Bid,
         },
     };
 


### PR DESCRIPTION
```shell
$ cargo r --release --bin generator -- -n 5000000 -j 4 | cargo r --bin matching-engine --profile bench -- -j 4
    Finished `bench` profile [optimized + debuginfo] target(s) in 0.09s
     Running `target/release/matching-engine -j 4`
    Finished `release` profile [optimized] target(s) in 0.09s
     Running `target/release/generator -n 5000000 -j 4`
       Total 5 000 000 order(s) in 3.02s
     Average 1 653 741.19 orders/s

 Orderbook info
    Spread
     Ask 4859
     Bid 2464
    Length
     Ask 544921
     Bid 544012
```